### PR TITLE
Avoid exporting non-localized entries

### DIFF
--- a/lib/export/entries.js
+++ b/lib/export/entries.js
@@ -130,7 +130,10 @@ exportEntries.prototype.getEntries = function (apiDetails) {
       locale: apiDetails.locale,
       skip: apiDetails.skip,
       limit: limit,
-      include_count: true
+      include_count: true,
+      query: {
+        locale: apiDetails.locale
+      }
     };
 
     return request(requestObject).then(function (response) {


### PR DESCRIPTION
Exporting non-localized entries results in contentstack-import creating localized versions of the same.

By not exporting those objects, we can can avoid the bug. 

Improves import utility library speed by "x" times the language present in the stack.