### PR TITLE
index.js: correct error wording

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -14,7 +14,7 @@ exports.validateConfig = function(config) {
   }
 
   if(config.email && config.password && !config.access_token || !config.source_stack) {
-    throw new Error('Kindly provide access_token or api_token');  
+    throw new Error('Kindly provide access_token or source_stack');  
   } else if(!config.email && !config.password && !config.management_token && !config.source_stack && !config.access_token) {
     throw new Error('Kindly provide management_token or email and password');
   } else if(config.email && config.password && !config.access_token && config.source_stack) {


### PR DESCRIPTION
`api_token` is not used elsewhere or [documented](https://www.contentstack.com/docs/search/?q=api_token): shouldn't this be `source_stack`?