### PR TITLE
Add support for EU Contentstack API URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Update configuration details at config/index.js
  access_token: '' // Stack access_token
  management_token: '' //Stack management_token
  data: '' // Relative path to the directory, where exported data is to be stored. ex: './contents'
+ useEUApi: false // Set to true if your stacks are hosted in the Europe
  ...
 }
 ```
-    
+
 ## Usage
 After setting the configuration, you'll can run the below given commands!
 
@@ -40,7 +41,7 @@ After setting the configuration, you'll can run the below given commands!
 ```bash
 $ npm run export
 ```
-  
+
 2. Export a specific module
 ```bash
 $ npm run export-assets

--- a/config/default.js
+++ b/config/default.js
@@ -1,4 +1,6 @@
-module.exports = {
+var _ = require('lodash')
+
+const defaultConfig = {
   versioning: false,
   host: 'https://api.contentstack.io/v3',
   cdn: 'https://cdn.contentstack.io/v3',
@@ -110,7 +112,7 @@ module.exports = {
     userSession: '/user-session/',
     globalfields: '/global_fields/',
     locales: '/locales/',
-    labels: '/labels/',    
+    labels: '/labels/',
     environments: '/environments/',
     assets: '/assets/',
     content_types: '/content_types/',
@@ -121,4 +123,15 @@ module.exports = {
     stacks: '/stacks/'
   },
   preserveStackVersion: false
+}
+
+module.exports = function (useEUApi) {
+  if (!useEUApi) return defaultConfig;
+
+  const euHosts = {
+    host: 'https://eu-api.contentstack.com/v3',
+    cdn: 'https://eu-cdn.contentstack.com/v3',
+  }
+
+  return _.merge(defaultConfig, euHosts);
 }

--- a/config/index.js
+++ b/config/index.js
@@ -10,7 +10,8 @@ module.exports = {
   // Stack API KEY
   source_stack: '',             // mandatory
   access_token: '',
-  management_token: '',    
+  management_token: '',
   // Path where the exported data will be stored (relative path)
-  data: './contents'
+  data: './contents',
+  useEUApi: false
 };

--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -42,7 +42,8 @@ async function validateEmail(email) {
 }
 
 exports.buildAppConfig = function (config) {
-  config = _.merge(defaultConfig, config)
+  const { useEUApi, ...config } = config
+  config = _.merge(defaultConfig(useEUApi), config)
   config.headers = {
     api_key: config.source_stack,
     authorization: config.management_token,


### PR DESCRIPTION
Currently, I am unable to access stacks on the EU Contentstack instance without manually updating the `default` config to use the correct EU URLs.

This PR adds a new user config option to switch the URLs in the `default` config to the EU versions. 